### PR TITLE
Change params order for email_address_with_name method

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1438,7 +1438,7 @@ If you're using Rails 6.1 or higher, you can use the `email_address_with_name` m
 [source,ruby]
 ----
 # in your mailer class
-default from: email_address_with_name('Your Name', 'info@your_site.com')
+default from: email_address_with_name('info@your_site.com', 'Your Name')
 ----
 
 === Delivery Method Test [[delivery-method-test]]


### PR DESCRIPTION
Hi!

According to the [docs](https://apidock.com/rails/ActionMailer/Base/email_address_with_name/class) we have to pass the email by first parameter to the method and the name as a second one.
Otherwise we will catch an `Mail::Field::IncompleteParseError`.

Best regards,
Georgiy