### PR TITLE
Remove Explicit FK naming guideline?

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1169,27 +1169,6 @@ class ModifyDefaultStatusForProducts < ActiveRecord::Migration
 end
 ----
 
-=== Meaningful Foreign Key Naming [[meaningful-foreign-key-naming]]
-
-Name your foreign keys explicitly instead of relying on Rails auto-generated FK names. (https://guides.rubyonrails.org/active_record_migrations.html#foreign-keys)
-
-[source,ruby]
-----
-# bad
-class AddFkArticlesToAuthors < ActiveRecord::Migration
-  def change
-    add_foreign_key :articles, :authors
-  end
-end
-
-# good
-class AddFkArticlesToAuthors < ActiveRecord::Migration
-  def change
-    add_foreign_key :articles, :authors, name: :articles_author_id_fk
-  end
-end
-----
-
 === Reversible Migration [[reversible-migration]]
 
 Don't use non-reversible migration commands in the `change` method.


### PR DESCRIPTION
It was initially introduced in https://github.com/rubocop/rails-style-guide/pull/189

:warning: This is more a call for a discussion than a call to remove the guideline.

The guideline only mentions `add_foreign_key`, but has no mention of [`t.references`/`t.belongs_to`](https://api.rubyonrails.org/classes/ActiveRecord/ConnectionAdapters/Table.html#method-i-references)/[`add_reference`/`add_belongs_to`](https://api.rubyonrails.org/classes/ActiveRecord/ConnectionAdapters/SchemaStatements.html#method-i-add_reference) that do add a FK, that also accept a `name` option.

## Why Rails doesn't do this for us?

The code as we see it today to generate `fk_rails_...` FK names has not changes much since [7 years ago](https://github.com/rails/rails/commit/b8e1f202676b4788c56241b124c401beff9f4014), but it does not explain why `<table_name>_<column_name>_fk` was not considered.
```
        def foreign_key_name(table_name, options)
          options.fetch(:name) do
            identifier = "#{table_name}_#{options.fetch(:column)}_fk"
            hashed_identifier = OpenSSL::Digest::SHA256.hexdigest(identifier).first(10)

            "fk_rails_#{hashed_identifier}"
          end
        end
```

## Does the initial reasoning still stand?

The idea behind the "figuring out" in the original reasoning is not clear to me at all:

> Figuring out FK constraints named fk_rails_3232112 is not the coolest thing.

```
$ psql mydb
[local] pirj@mydb=# \d users
                                              Table "public.users"
...
Referenced by:
    TABLE "books" CONSTRAINT "fk_rails_8071a77193" FOREIGN KEY (user_id) REFERENCES users(id)
```
Seems pretty straightforward in that direction. Doable in the other direction, too, but the query is indeed something one needs to look up and copy-paste.

## The current state of affairs

However, in practice, according to https://github.com/eliotsykes/real-world-rails, **all of 669 `add_foreign_key` statements do define a custom FK name**.
[89 of them (gitlabhq)](https://github.com/gitlabhq/gitlabhq/blob/2c41816276a9bb5c12176cb2d2b54c4d19c0ce2c/db/migrate/20181228175414_init_schema.rb#L2355) have nonsensical names, though:
```
add_foreign_key "releases", "users", column: "author_id", name: "fk_8e4456f90f"
add_foreign_key "todos", "projects", name: "fk_45054f9c45"
```