### PR TITLE
Relax dot-separated locale keys guideline

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1326,7 +1326,7 @@ Use the short form of the I18n methods: `I18n.t` instead of `I18n.translate` and
 
 === Lazy Lookup [[lazy-lookup]]
 
-Use "lazy" lookup for the texts used in views. Let's say we have the following structure:
+Use "lazy" lookup for locale entries from views and controllers. Let's say we have the following structure:
 
 ----
 en:
@@ -1339,6 +1339,10 @@ The value for `users.show.title` can be looked up in the template `app/views/use
 
 [source,ruby]
 ----
+# bad
+= t 'users.show.title'
+
+# good
 = t '.title'
 ----
 

--- a/README.adoc
+++ b/README.adoc
@@ -1348,8 +1348,8 @@ The value for `users.show.title` can be looked up in the template `app/views/use
 
 === Dot-separated Keys [[dot-separated-keys]]
 
-Use the dot-separated keys in the controllers and models instead of specifying the `:scope` option.
-The dot-separated call is easier to read and trace the hierarchy.
+Use dot-separated locale keys instead of specifying the `:scope` option with an array or a single symbol.
+Dot-separated notation is easier to read and trace the hierarchy.
 
 [source,ruby]
 ----
@@ -1357,7 +1357,14 @@ The dot-separated call is easier to read and trace the hierarchy.
 I18n.t :record_invalid, scope: [:activerecord, :errors, :messages]
 
 # good
+I18n.t :record_invalid, scope: 'activerecord.errors.messages'
 I18n.t 'activerecord.errors.messages.record_invalid'
+
+# bad
+I18n.t :title, scope: :invitation
+
+# good
+I18n.t 'title.invitation'
 ----
 
 === I18n Guides [[i18n-guides]]


### PR DESCRIPTION
Along the way, clarify [Lazy lookup](https://guides.rubyonrails.org/i18n.html#lazy-lookup) guideline a bit:

"the texts" is quite vague, as it stands for:
> strings and other locale specific bits (such as date or currency formats)

I believe "entries" is a better term.

Lazy lookup is also available in controllers, see https://github.com/rails/rails/blob/fee61e3abc878e4d4930a0be0accf8e4569009a8/actionpack/lib/abstract_controller/translation.rb#L11
PS Except `ActionController::Api`. Only `ActionController::Base`.