### PR TITLE
Fix code highlighting issues

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -657,15 +657,15 @@ end
 Order callback declarations in the order in which they will be executed.
 For reference, see https://guides.rubyonrails.org/active_record_callbacks.html#available-callbacks[Available Callbacks].
 
-[source,Ruby]
+[source,ruby]
 ----
-#bad
+# bad
 class Person
   after_commit :after_commit_callback
   before_validation :before_validation_callback
 end
 
-#good
+# good
 class Person
   before_validation :before_validation_callback
   after_commit :after_commit_callback
@@ -978,7 +978,7 @@ User.pick(:name)
 
 Favor the use of `ids` over `pluck(:id)`.
 
-[source,Ruby]
+[source,ruby]
 ----
 # bad
 User.pluck(:id)


### PR DESCRIPTION
This little change fixes the code highlighting in two places, which only seems to happen on the generated doc (when using asciidoctor + rouge):

![2022-01-05-101104_1015x399_scrot](https://user-images.githubusercontent.com/4298119/148224563-c82b0d4f-9bc7-4401-b789-6e6d68d30c42.png)
