### PR TITLE
Remove outdated platform advice

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1705,32 +1705,6 @@ Put gems used only for development or testing in the appropriate group in the Ge
 Use only established gems in your projects.
 If you're contemplating on including some little-known gem you should do a careful review of its source code first.
 
-=== OS-specific `Gemfile.lock` [[os-specific-gemfile-locks]]
-
-OS-specific gems will by default result in a constantly changing `Gemfile.lock` for projects with multiple developers using different operating systems.
-Add all OS X specific gems to a `darwin` group in the Gemfile, and all Linux specific gems to a `linux` group:
-
-[source,ruby]
-----
-# Gemfile
-group :darwin do
-  gem 'rb-fsevent'
-  gem 'growl'
-end
-
-group :linux do
-  gem 'rb-inotify'
-end
-----
-
-To require the appropriate gems in the right environment, add the following to `config/application.rb`:
-
-[source,ruby]
-----
-platform = RUBY_PLATFORM.match(/(linux|darwin)/)[0].to_sym
-Bundler.require(platform)
-----
-
 === `Gemfile.lock` [[gemfile-lock]]
 
 Do not remove the `Gemfile.lock` from version control.


### PR DESCRIPTION
I expect this was added before Bundler had proper support for multiple platforms.