### PR TITLE
Update links that make use of deprecated git.io

### DIFF
--- a/.github/workflows/spell_checking.yml
+++ b/.github/workflows/spell_checking.yml
@@ -28,6 +28,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install
-        run: wget -O - -q https://git.io/misspell | sh -s -- -b .
+        run: wget -O - -q https://raw.githubusercontent.com/client9/misspell/master/install-misspell.sh | sh -s -- -b .
       - name: Misspell
         run: ./misspell -error


### PR DESCRIPTION
Reference: https://github.blog/changelog/2022-04-25-git-io-deprecation/