### PR TITLE
Add "Prefer using squiggly heredoc over `strip_heredoc`" rule

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1575,6 +1575,28 @@ hash.exclude?(:key)
 string.exclude?('substring')
 ----
 
+=== Prefer using squiggly heredoc over `strip_heredoc` [[prefer-squiggly-heredoc]]
+
+If you're using Ruby 2.3 or higher, prefer squiggly heredoc (`<<~`) over Active Support's `strip_heredoc`.
+
+[source,ruby]
+----
+# bad
+<<EOS.strip_heredoc
+  some text
+EOS
+
+# bad
+<<-EOS.strip_heredoc
+  some text
+EOS
+
+# good
+<<~EOS
+  some text
+EOS
+----
+
 === Prefer `to_fs` for Formatted Strings [[prefer-to-fs]]
 
 If you're using Rails 7.0 or higher, prefer `to_fs` over `to_formatted_s`. `to_formatted_s` is just too cumbersome for a method used that frequently.


### PR DESCRIPTION
Follow up https://github.com/rubocop/rubocop-rails/pull/706.

This PR adds "Prefer using squiggly heredoc over `strip_heredoc`" rule.