### PR TITLE
Add "Finding missing relationship records" rule

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -938,6 +938,19 @@ User.where("id != ?", id)
 User.where.not(id: id)
 ----
 
+=== Finding missing relationship records [[finding-missing-relationship-records]]
+
+If you're using Rails 6.1 or higher, use https://api.rubyonrails.org/classes/ActiveRecord/QueryMethods/WhereChain.html#method-i-missing[where.missing] to find missing relationship records.
+
+[source,ruby]
+----
+# bad
+Post.left_joins(:author).where(authors: { id: nil })
+
+# good
+Post.where.missing(:author)
+----
+
 === Order by `id` [[order-by-id]]
 
 Don't use the `id` column for ordering.


### PR DESCRIPTION
If you're using Rails 6.1 or higher, prefer `where.missing` over `left_joins` and `where` to find missing relationship records.
It can be expressed in a more simplified.

```ruby
# bad
Post.left_joins(:author).where(authors: { id: nil })

# good
Post.where.missing(:author)
```