### PR TITLE
avoiding the use of the StandardError exception

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -337,6 +337,44 @@ render status: :forbidden
 ...
 ----
 
+=== Error Message [[http-status-code-symbols]]
+
+It is recommended to avoid using the StandardError exception when rendering error messages in the code, as this may capture an unintended and controlled error. 
+Instead, it is suggested to capture specific errors or send a customized standard error message. 
+This ensures more accurate and effective exception handling in the program. 
+
+[source,ruby]
+----
+# bad
+...
+rescue StandardError => e
+  render json: {error_msg: e.message}
+end
+...
+
+# bad - usign in flash message
+...
+rescue StandardError => e
+      flash[:error] = e.message
+end
+...
+
+
+# good
+...
+rescue StandardError => e
+  render json: {error_msg: 'Error in the application'}
+end
+...
+
+# good
+...
+rescue ParticularError => e
+  render json: {error_msg: e.message}
+end
+...
+----
+
 == Models
 
 === Model Classes [[model-classes]]


### PR DESCRIPTION
In general, it is better to rescue and display the specific error rather than showing a generic message in the view when working with Ruby. This is because a generic message may not provide enough information for the user to understand the problem and take steps to solve it.

By rescuing and displaying the specific error, more detailed information about the nature of the problem can be provided, which can help the user understand what went wrong and how to fix it.

I hope you consider this PR please, it would be my first contribution.