### PR TITLE
Fix typo in the Beware Skip Model Validations section

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -696,7 +696,7 @@ Article.first.decrement!(:view_count)
 DiscussionBoard.decrement_counter(:post_count, 5)
 Article.first.increment!(:view_count)
 DiscussionBoard.increment_counter(:post_count, 5)
-person.toggle :active
+person.toggle! :active
 product.touch
 Billing.update_all("category = 'authorized', author = 'David'")
 user.update_attribute(:website, 'example.com')


### PR DESCRIPTION
The `#toggle` method does not update a record, but the `#toggle!` method does.

Reference: https://api.rubyonrails.org/v7.0.6/classes/ActiveRecord/Persistence.html#method-i-toggle
