### PR TITLE
Add the update_only option to accepts_nested_attributes_for attributes writers

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -814,6 +814,25 @@ class Post < ApplicationRecord
 end
 ----
 
+=== `accepts_nested_attributes_for` Update Only Option [[accepts_nested_attributes_for-update_only-option]]
+
+Define the `update_only` option to the `accepts_nested_attributes_for` attributes writers.
+
+[source,ruby]
+----
+# bad
+class Member < ApplicationRecord
+  has_one :avatar
+  accepts_nested_attributes_for :avatar
+end
+
+# good
+class Member < ApplicationRecord
+  has_one :avatar
+  accepts_nested_attributes_for :avatar, update_only: true
+end
+----
+
 === `save!` [[save-bang]]
 
 When persisting AR objects always use the exception raising bang! method or handle the method return value.


### PR DESCRIPTION
Goes with https://github.com/rubocop/rubocop-rails/pull/1035.

When using [`accepts_nested_attributes_for`](https://api.rubyonrails.org/classes/ActiveRecord/NestedAttributes/ClassMethods.html#method-i-accepts_nested_attributes_for), it is preferable to make an explicit decision regarding how nested attributes are going to be used when an associated record already exists.
