### PR TITLE
Add word that failed in CI's spell check to the whitelist

### DIFF
--- a/codespell.txt
+++ b/codespell.txt
@@ -1,1 +1,2 @@
+mange
 rouge


### PR DESCRIPTION
When I opened https://github.com/rubocop/rails-style-guide/pull/348, the CI's spellcheck failed. 
https://github.com/rubocop/rails-style-guide/actions/runs/6570237096/job/17847343002?pr=348

I addressed the issue by adding the relevant word to the whitelist.
