### PR TITLE
Fix code in the "Prefer using squiggly heredoc over strip_heredoc" section

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1689,7 +1689,7 @@ If you're using Ruby 2.3 or higher, prefer squiggly heredoc (`<<~`) over Active 
 [source,ruby]
 ----
 # bad
-<<EOS.strip_heredoc
+<<~EOS.strip_heredoc
   some text
 EOS
 


### PR DESCRIPTION
The original example is invalid, so I fixed it.