### PR TITLE
Add a style guide to suggest to pass a string literal as a URL to http method calls

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -231,6 +231,23 @@ match ':controller(/:action(/:id(.:format)))'
 
 Don't use `match` to define any routes unless there is need to map multiple request types among `[:get, :post, :patch, :put, :delete]` to a single action using `:via` option.
 
+=== HTTP URL [[http-url]]
+
+Prefer passing a string literal as a URL to HTTP methods to make the actual URL obvious and to facilitate tracking endpoint path changes.
+
+[source,ruby]
+----
+# bad
+get photos_path
+put photo_path(id)
+post edit_photo_path(id)
+
+# good
+get "/photos"
+put "/photos/#{id}"
+post "/photos/#{id}/edit"
+----
+
 == Controllers
 
 === Skinny Controllers [[skinny-controllers]]


### PR DESCRIPTION
Original discussion: https://github.com/rubocop/rails-style-guide/issues/328