### PR TITLE
Un-break PragProg links

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1933,10 +1933,10 @@ There are a few excellent resources on Rails style, that you should consider if 
 
 * https://www.informit.com/store/rails-5-way-9780134657677[The Rails 5 Way]
 * https://guides.rubyonrails.org/[Ruby on Rails Guides]
-* https://pragprog.com/book/rspec3/effective-testing-with-rspec-3[Effective Testing with RSpec 3]
-* https://pragprog.com/book/hwcuc/the-cucumber-book[The Cucumber Book]
+* https://pragprog.com/titles/rspec3/effective-testing-with-rspec-3/[Effective Testing with RSpec 3]
+* https://pragprog.com/titles/hwcuc/the-cucumber-book/[The Cucumber Book]
 * https://leanpub.com/everydayrailsrspec[Everyday Rails Testing with RSpec]
-* https://pragprog.com/book/nrtest3/rails-5-test-prescriptions[Rails 5 Test Prescriptions]
+* https://pragprog.com/titles/nrtest3/rails-5-test-prescriptions/[Rails 5 Test Prescriptions]
 * https://rspec.rubystyle.guide[RSpec Style Guide]
 
 == Contributing

--- a/README.adoc
+++ b/README.adoc
@@ -1934,7 +1934,7 @@ There are a few excellent resources on Rails style, that you should consider if 
 * https://www.informit.com/store/rails-5-way-9780134657677[The Rails 5 Way]
 * https://guides.rubyonrails.org/[Ruby on Rails Guides]
 * https://pragprog.com/titles/rspec3/effective-testing-with-rspec-3/[Effective Testing with RSpec 3]
-* https://pragprog.com/titles/hwcuc/the-cucumber-book/[The Cucumber Book]
+* https://pragprog.com/titles/hwcuc2/the-cucumber-book-second-edition/[The Cucumber Book]
 * https://leanpub.com/everydayrailsrspec[Everyday Rails Testing with RSpec]
 * https://pragprog.com/titles/nrtest3/rails-5-test-prescriptions/[Rails 5 Test Prescriptions]
 * https://rspec.rubystyle.guide[RSpec Style Guide]


### PR DESCRIPTION
It appears PragProg updated "book" to "titles" in their URL structure. Additionally, I added the second edition of the Cucumber book as the destination for "The Cucumber Book".