### PR TITLE
Update `Enum` syntax

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -430,10 +430,10 @@ lead to broken code.
 ----
 class Transaction < ApplicationRecord
   # bad - implicit values - ordering matters
-  enum type: %i[credit debit]
+  enum :type, %i[credit debit]
 
   # good - explicit values - ordering does not matter
-  enum type: {
+  enum :type, {
     credit: 0,
     debit: 1
   }


### PR DESCRIPTION
Updates the enum to show syntax that was introduced in Rails 7.