### PR TITLE
Add Order arguments section

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -967,6 +967,21 @@ scope :chronological, -> { order(id: :asc) }
 scope :chronological, -> { order(created_at: :asc) }
 ----
 
+=== Order arguments [[order-arguments]]
+
+Prefer symbol arguments over strings for ordering.
+
+String columns without a table name can cause an "ambiguous column name" error when ordering by a column that exists in multiple tables joined in the same query.
+
+[source,ruby]
+----
+# bad
+User.order('created_at DESC')
+
+# good
+User.order(created_at: :desc)
+----
+
 === `pluck`
 
 Use https://api.rubyonrails.org/classes/ActiveRecord/Calculations.html#method-i-pluck[pluck] to select a single value from multiple records.


### PR DESCRIPTION
Adds a section for [`order`](https://api.rubyonrails.org/classes/ActiveRecord/QueryMethods.html#method-i-order) arguments, giving preference to symbol arguments over strings.

PR for the cop: https://github.com/rubocop/rubocop-rails/pull/1501